### PR TITLE
bump version

### DIFF
--- a/lib/prometheus/client/version.rb
+++ b/lib/prometheus/client/version.rb
@@ -2,6 +2,6 @@
 
 module Prometheus
   module Client
-    VERSION = '0.7.1'
+    VERSION = '0.7.3'
   end
 end


### PR DESCRIPTION
Missed this when I merged the previous PR (there's already a 0.7.2 tagged release so that's why this value)